### PR TITLE
feat: Add mapping for Croove and Rogowski in h3d_mapping.py

### DIFF
--- a/roles/cron/scripts/h3d/h3d_mapping.py
+++ b/roles/cron/scripts/h3d/h3d_mapping.py
@@ -62,6 +62,7 @@ regex_dict = {
     r"RashNemain": "[RashNemain]",
     r"RedHot": "[RedHot]",
     r"Redmoa": "[Redmoa]",
+    r"Rogowski": "[Rogowski]",
     r"Rushzilla": "[Rushzilla]",
     r"SaveAss": "[SaveAss]",
     r"Secazz": "[Secazz]",


### PR DESCRIPTION
Added mappings for Croove and Rogowski in the regex_dict dictionary to ensure
proper replacement in the h3d_mapping script. Croove mapped to [Croove] and
Rogowski mapped to [Rogowski].